### PR TITLE
Packet reporting

### DIFF
--- a/src/include/private/switch_core_pvt.h
+++ b/src/include/private/switch_core_pvt.h
@@ -170,6 +170,8 @@ struct switch_core_session {
 	switch_buffer_t *text_line_buffer;
 	switch_mutex_t *text_mutex;
 	const char *external_id;
+
+	packet_stats_t stats;
 };
 
 struct switch_media_bug {

--- a/src/include/switch_core.h
+++ b/src/include/switch_core.h
@@ -90,6 +90,33 @@ typedef struct device_uuid_node_s {
 	struct device_uuid_node_s *next;
 } switch_device_node_t;
 
+/// PACKET STATS ///
+typedef struct packet_stats_io_info {
+	char* in_codec;
+	uint32_t in_ssrc;
+	switch_sockaddr_t *in_remote_addr;
+	switch_sockaddr_t *in_local_addr;
+	char* out_codec;
+	uint32_t out_ssrc;
+	switch_sockaddr_t *out_remote_addr;
+	switch_sockaddr_t *out_local_addr;
+        int32_t count; // count of packets going out
+} packet_stats_io_info_t; 
+
+typedef struct packet_stats {
+        int min;
+        int max;
+        float average;  // weigthed average, estimate of the last few weeks
+        float stdev;    // last standard deviation
+        float estimate; // short term estimate, EWMA exponential weighted moving average
+        double m2;      // sum of squares, used for recursive variance calculation
+        int32_t in_count;
+        int32_t in_plc;
+        int32_t count;
+	packet_stats_io_info_t io_info;
+} packet_stats_t;
+/// PACKET STATS ///
+
 typedef struct switch_device_stats_s {
 	uint32_t total;
 	uint32_t total_in;
@@ -255,6 +282,10 @@ static inline void *switch_must_realloc(void *_b, size_t _z)
 ///\{
 
 
+SWITCH_DECLARE(void) switch_core_session_increment_read(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_session_increment_plc(switch_core_session_t *session);
+SWITCH_DECLARE(void) packet_stats_print(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_session_set_io_stats(switch_core_session_t *session, packet_stats_io_info_t *packet_stats_io_info);
 SWITCH_DECLARE(void) switch_core_screen_size(int *x, int *y);
 SWITCH_DECLARE(void) switch_core_session_sched_heartbeat(switch_core_session_t *session, uint32_t seconds);
 SWITCH_DECLARE(void) switch_core_session_unsched_heartbeat(switch_core_session_t *session);

--- a/src/include/switch_core.h
+++ b/src/include/switch_core.h
@@ -92,16 +92,18 @@ typedef struct device_uuid_node_s {
 
 /// PACKET STATS ///
 typedef struct packet_stats_io_info {
+	const char* in_callid;
 	char* in_codec;
 	uint32_t in_ssrc;
 	switch_sockaddr_t *in_remote_addr;
 	switch_sockaddr_t *in_local_addr;
+	const char* out_callid;
 	char* out_codec;
 	uint32_t out_ssrc;
 	switch_sockaddr_t *out_remote_addr;
 	switch_sockaddr_t *out_local_addr;
         int32_t count; // count of packets going out
-} packet_stats_io_info_t; 
+} packet_stats_io_info_t;
 
 typedef struct packet_stats {
         int min;
@@ -114,6 +116,7 @@ typedef struct packet_stats {
         int32_t in_plc;
         int32_t count;
 	packet_stats_io_info_t io_info;
+	switch_bool_t reported;
 } packet_stats_t;
 /// PACKET STATS ///
 

--- a/src/include/switch_frame.h
+++ b/src/include/switch_frame.h
@@ -50,6 +50,10 @@ typedef struct switch_frame_geometry {
 	int32_t X;
 } switch_frame_geometry_t;
 
+typedef struct switch_frame_extra {
+	switch_time_t received_ts;
+} switch_frame_extra_t;
+
 /*! \brief An abstraction of a data frame */
 	struct switch_frame {
 	/*! a pointer to the codec information */
@@ -87,6 +91,7 @@ typedef struct switch_frame_geometry {
 	payload_map_t *pmap;
 	switch_image_t *img;
 	struct switch_frame_geometry geometry;
+	switch_frame_extra_t extra;
 };
 
 SWITCH_END_EXTERN_C

--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -57,6 +57,7 @@ typedef struct {
 	char body[SWITCH_RTP_MAX_BUF_LEN+4+sizeof(char *)];
 	switch_rtp_hdr_ext_t *ext;
 	char *ebody;
+	switch_time_t received_ts;
 } switch_rtp_packet_t;
 
 typedef enum {

--- a/src/switch_core.c
+++ b/src/switch_core.c
@@ -128,8 +128,6 @@ static void send_heartbeat(void)
 static char main_ip4[256] = "";
 static char main_ip6[256] = "";
 
-
-
 static void check_ip(void)
 {
 	char guess_ip4[256] = "";

--- a/src/switch_core.c
+++ b/src/switch_core.c
@@ -128,6 +128,8 @@ static void send_heartbeat(void)
 static char main_ip4[256] = "";
 static char main_ip6[256] = "";
 
+
+
 static void check_ip(void)
 {
 	char guess_ip4[256] = "";

--- a/src/switch_core_io.c
+++ b/src/switch_core_io.c
@@ -74,7 +74,6 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 	unsigned int flag = 0;
 	int i;
 
-	// switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, ">>> switch_core_session_read_frame <<<\n");
 	switch_assert(session != NULL);
 
 	tap_only = switch_test_flag(session, SSF_MEDIA_BUG_TAP_ONLY);
@@ -101,7 +100,6 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 		if (switch_channel_test_flag(session->channel, CF_AUDIO_PAUSE_READ)) {
 			switch_yield(20000);
 			*frame = &runtime.dummy_cng_frame;
-			// switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Media Paused!!!!\n");
 			return SWITCH_STATUS_SUCCESS;
 		}
 

--- a/src/switch_core_io.c
+++ b/src/switch_core_io.c
@@ -74,6 +74,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 	unsigned int flag = 0;
 	int i;
 
+	// switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, ">>> switch_core_session_read_frame <<<\n");
 	switch_assert(session != NULL);
 
 	tap_only = switch_test_flag(session, SSF_MEDIA_BUG_TAP_ONLY);
@@ -170,6 +171,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 	}
 
 	if (session->endpoint_interface->io_routines->read_frame) {
+		// switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "endpoint_interface->io_routines->read_frame\n");
+
 		switch_mutex_unlock(session->read_codec->mutex);
 		switch_mutex_unlock(session->codec_read_mutex);
 		if ((status = session->endpoint_interface->io_routines->read_frame(session, frame, flags, stream_id)) == SWITCH_STATUS_SUCCESS) {

--- a/src/switch_core_session.c
+++ b/src/switch_core_session.c
@@ -36,10 +36,33 @@
 #include "switch.h"
 #include "switch_core.h"
 #include "private/switch_core_pvt.h"
+#include <fspr_network_io.h>
+
 
 #define DEBUG_THREAD_POOL
 
 struct switch_session_manager session_manager;
+
+SWITCH_DECLARE(void) switch_core_session_increment_plc(switch_core_session_t *session)
+{
+	session->stats.in_plc++;
+}
+
+SWITCH_DECLARE(void) switch_core_session_increment_read(switch_core_session_t *session)
+{
+	session->stats.in_count++;
+}
+
+SWITCH_DECLARE(void) switch_core_session_set_io_stats(switch_core_session_t *session, packet_stats_io_info_t *packet_stats_io_info)
+{
+	session->stats.io_info.out_remote_addr = packet_stats_io_info->out_remote_addr;
+	session->stats.io_info.out_local_addr = packet_stats_io_info->out_local_addr;
+	session->stats.io_info.out_ssrc = packet_stats_io_info->out_ssrc;
+	session->stats.io_info.in_remote_addr = packet_stats_io_info->in_remote_addr;
+	session->stats.io_info.in_local_addr = packet_stats_io_info->in_local_addr;
+	session->stats.io_info.in_ssrc = packet_stats_io_info->in_ssrc;
+}
+
 
 SWITCH_DECLARE(void) switch_core_session_set_dmachine(switch_core_session_t *session, switch_ivr_dmachine_t *dmachine, switch_digit_action_target_t target)
 {
@@ -1493,6 +1516,8 @@ SWITCH_DECLARE(void) switch_core_session_signal_state_change(switch_core_session
 			}
 		}
 	}
+	// TODO
+	packet_stats_print(session);
 	switch_core_session_kill_channel(session, SWITCH_SIG_BREAK);
 }
 

--- a/src/switch_core_session.c
+++ b/src/switch_core_session.c
@@ -38,7 +38,6 @@
 #include "private/switch_core_pvt.h"
 #include <fspr_network_io.h>
 
-
 #define DEBUG_THREAD_POOL
 
 struct switch_session_manager session_manager;
@@ -55,14 +54,24 @@ SWITCH_DECLARE(void) switch_core_session_increment_read(switch_core_session_t *s
 
 SWITCH_DECLARE(void) switch_core_session_set_io_stats(switch_core_session_t *session, packet_stats_io_info_t *packet_stats_io_info)
 {
+	if ((session->stats.io_info.out_ssrc != 0 && session->stats.io_info.out_ssrc != packet_stats_io_info->out_ssrc)
+	 || (session->stats.io_info.in_ssrc != 0 && session->stats.io_info.in_ssrc != packet_stats_io_info->in_ssrc)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "SSRC change[%u][%u] [%u][%u]\n",
+				session->stats.io_info.out_ssrc, packet_stats_io_info->out_ssrc,
+				session->stats.io_info.in_ssrc, packet_stats_io_info->in_ssrc
+				);
+		packet_stats_print(session);
+		memset(&session->stats, '\0', sizeof(packet_stats_t));
+	}
 	session->stats.io_info.out_remote_addr = packet_stats_io_info->out_remote_addr;
 	session->stats.io_info.out_local_addr = packet_stats_io_info->out_local_addr;
 	session->stats.io_info.out_ssrc = packet_stats_io_info->out_ssrc;
+	session->stats.io_info.out_callid = packet_stats_io_info->out_callid;
 	session->stats.io_info.in_remote_addr = packet_stats_io_info->in_remote_addr;
 	session->stats.io_info.in_local_addr = packet_stats_io_info->in_local_addr;
 	session->stats.io_info.in_ssrc = packet_stats_io_info->in_ssrc;
+	session->stats.io_info.in_callid = packet_stats_io_info->in_callid;
 }
-
 
 SWITCH_DECLARE(void) switch_core_session_set_dmachine(switch_core_session_t *session, switch_ivr_dmachine_t *dmachine, switch_digit_action_target_t target)
 {
@@ -1516,7 +1525,6 @@ SWITCH_DECLARE(void) switch_core_session_signal_state_change(switch_core_session
 			}
 		}
 	}
-	// TODO
 	packet_stats_print(session);
 	switch_core_session_kill_channel(session, SWITCH_SIG_BREAK);
 }

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -571,15 +571,12 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 
 		switch_ivr_parse_all_messages(session_a);
 
-
 		if (!inner_bridge && (switch_channel_test_flag(chan_a, CF_SUSPEND) || switch_channel_test_flag(chan_b, CF_SUSPEND))) {
-
 			status = switch_core_session_read_frame(session_a, &read_frame, SWITCH_IO_FLAG_NONE, stream_id);
 
 			if (!SWITCH_READ_ACCEPTABLE(status)) {
 				goto end_of_bridge_loop;
 			}
-//		        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_CRIT, ">>>> ivr_bridge - switch_core_session_read_frame ssrc[0x%08X] <<<<\n", read_frame->ssrc);
 			continue;
 		}
 
@@ -798,18 +795,17 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 		}
 
 
-
 		/* read audio from 1 channel and write it to the other */
 		status = switch_core_session_read_frame(session_a, &read_frame, SWITCH_IO_FLAG_NONE, stream_id);
 
 		if (SWITCH_READ_ACCEPTABLE(status)) {
-		        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_CRIT, ">>>> ivr_bridge - switch_core_session_read_frame ssrc[0x%08X]seq[%u]ts[%u]codec[%s]ts[%u] 1t1 <<<<\n",
-					read_frame->ssrc,
-					read_frame->seq,
-					read_frame->timestamp,
-					read_frame->codec->implementation->iananame,
-					(unsigned int)(read_frame->extra.received_ts/1000)
-					);
+		//        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_CRIT, ">>>> ivr_bridge - switch_core_session_read_frame ssrc[0x%08X]seq[%u]ts[%u]codec[%s]ts[%u] 1t1 <<<<\n",
+		//			read_frame->ssrc,
+		//			read_frame->seq,
+		//			read_frame->timestamp,
+		//			read_frame->codec->implementation->iananame,
+		//			(unsigned int)(read_frame->extra.received_ts/1000)
+		//			);
 			read_frame_count++;
 			if (switch_test_flag(read_frame, SFF_CNG)) {
 				if (silence_val) {
@@ -1432,8 +1428,6 @@ static switch_status_t signal_bridge_on_hangup(switch_core_session_t *session)
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 	switch_core_session_t *other_session;
 	switch_event_t *event;
-
-	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, ">>>> signal_bridge_on_hangup  <<<<");
 
 	if ((uuid = switch_channel_get_variable(channel, SWITCH_SIGNAL_BRIDGE_VARIABLE))) {
 		switch_channel_set_variable(channel, SWITCH_SIGNAL_BRIDGE_VARIABLE, NULL);

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -571,12 +571,15 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 
 		switch_ivr_parse_all_messages(session_a);
 
+
 		if (!inner_bridge && (switch_channel_test_flag(chan_a, CF_SUSPEND) || switch_channel_test_flag(chan_b, CF_SUSPEND))) {
+
 			status = switch_core_session_read_frame(session_a, &read_frame, SWITCH_IO_FLAG_NONE, stream_id);
 
 			if (!SWITCH_READ_ACCEPTABLE(status)) {
 				goto end_of_bridge_loop;
 			}
+//		        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_CRIT, ">>>> ivr_bridge - switch_core_session_read_frame ssrc[0x%08X] <<<<\n", read_frame->ssrc);
 			continue;
 		}
 
@@ -795,10 +798,18 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 		}
 
 
+
 		/* read audio from 1 channel and write it to the other */
 		status = switch_core_session_read_frame(session_a, &read_frame, SWITCH_IO_FLAG_NONE, stream_id);
 
 		if (SWITCH_READ_ACCEPTABLE(status)) {
+		        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_CRIT, ">>>> ivr_bridge - switch_core_session_read_frame ssrc[0x%08X]seq[%u]ts[%u]codec[%s]ts[%u] 1t1 <<<<\n",
+					read_frame->ssrc,
+					read_frame->seq,
+					read_frame->timestamp,
+					read_frame->codec->implementation->iananame,
+					(unsigned int)(read_frame->extra.received_ts/1000)
+					);
 			read_frame_count++;
 			if (switch_test_flag(read_frame, SFF_CNG)) {
 				if (silence_val) {
@@ -1421,6 +1432,8 @@ static switch_status_t signal_bridge_on_hangup(switch_core_session_t *session)
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 	switch_core_session_t *other_session;
 	switch_event_t *event;
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, ">>>> signal_bridge_on_hangup  <<<<");
 
 	if ((uuid = switch_channel_get_variable(channel, SWITCH_SIGNAL_BRIDGE_VARIABLE))) {
 		switch_channel_set_variable(channel, SWITCH_SIGNAL_BRIDGE_VARIABLE, NULL);

--- a/src/switch_jitterbuffer.c
+++ b/src/switch_jitterbuffer.c
@@ -67,6 +67,8 @@ typedef struct switch_jb_stats_s {
 	uint32_t size_max;
 	uint32_t size_est;
 	uint32_t acceleration;
+	uint32_t fast_acceleration;
+	uint32_t forced_acceleration;
 	uint32_t expand;
 	uint32_t jitter_max_ms;
 	int estimate_ms;
@@ -969,6 +971,8 @@ static inline int check_jb_size(switch_jb_t *jb)
 			switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_max_ms", "%u", jb->jitter.stats.size_max * packet_ms);
 			switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_est_ms", "%u", jb->jitter.stats.size_est * packet_ms);
 			switch_channel_set_variable_printf(jb->channel, "rtp_jb_acceleration_ms", "%u", jb->jitter.stats.acceleration * packet_ms);
+			switch_channel_set_variable_printf(jb->channel, "rtp_jb_fast_acceleration_ms", "%u", jb->jitter.stats.fast_acceleration * packet_ms);
+			switch_channel_set_variable_printf(jb->channel, "rtp_jb_forced_acceleration_ms", "%u", jb->jitter.stats.forced_acceleration * packet_ms);
 			switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_ms", "%u", jb->jitter.stats.expand * packet_ms);
 		}
 
@@ -1008,6 +1012,27 @@ static inline switch_status_t jb_next_packet_by_seq_with_acceleration(switch_jb_
 
 		jb->jitter.stats.estimate_ms = (int)((*jb->jitter.estimate) / ((jb->jitter.samples_per_second)) * 1000);
 		jb->jitter.stats.buffer_size_ms = (int)((visible_not_old * jb->jitter.samples_per_frame) / (jb->jitter.samples_per_second / 1000));
+
+		/* If the jitter buffer size is above the its max size, we force accelerate */
+		if (visible_not_old >= jb->max_frame_len) {
+			if (packet_vad(jb, packet, len) == SWITCH_FALSE) {
+				jb_debug(jb, SWITCH_LOG_WARNING, "JITTER_BUFFER above max size: [%d>%d] inactive fast acceleration\n", visible_not_old, jb->max_frame_len);
+				jb->jitter.drop_gap = 3;
+				jb->jitter.stats.acceleration++;
+				jb->jitter.stats.fast_acceleration++;
+				return jb_next_packet_by_seq(jb, nodep);
+			} else {
+				if (jb->jitter.drop_gap > 0) {
+					jb->jitter.drop_gap--;
+				} else {
+					jb_debug(jb, SWITCH_LOG_WARNING, "JITTER_BUFFER above max size: [%d>%d] forced acceleration\n", visible_not_old, jb->max_frame_len);
+					jb->jitter.drop_gap = 10;
+					jb->jitter.stats.acceleration++;
+					jb->jitter.stats.forced_acceleration++;
+					return jb_next_packet_by_seq(jb, nodep);
+				}
+			}
+		}
 
 		/* We try to accelerate in order to remove delay when the jitter buffer is 3x larger than the estimation. */
 		if (jb->jitter.stats.buffer_size_ms > (3 * jb->jitter.stats.estimate_ms) && jb->jitter.stats.buffer_size_ms > 60) {
@@ -1084,6 +1109,8 @@ SWITCH_DECLARE(void) switch_jb_set_jitter_estimator(switch_jb_t *jb, double *jit
 			switch_channel_set_variable_printf(jb->channel, "rtp_jb_max_ms", "%u", 0);
 			switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_ms", "%u", 0);
 			switch_channel_set_variable_printf(jb->channel, "rtp_jb_acceleration_ms", "%u", 0);
+			switch_channel_set_variable_printf(jb->channel, "rtp_jb_fast_acceleration_ms", "%u", 0);
+			switch_channel_set_variable_printf(jb->channel, "rtp_jb_forced_acceleration_ms", "%u", 0);
 			switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_ms", "%u", 0);
 			switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_max_ms", "%u", 0);
 			switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_ms", "%u", 0);


### PR DESCRIPTION
load tests with 150 sessions
![image](https://github.com/jchavanton/freeswitch/assets/3736014/7fe6d4c0-a391-4958-8fd6-d8a34dab656e)

![image](https://github.com/jchavanton/freeswitch/assets/3736014/90879b17-d2dc-485c-a37c-c6216a058574)


![image](https://github.com/jchavanton/freeswitch/assets/3736014/6b405efd-bc1c-41a9-9c78-3ac01b8752fe)



```
read_rtp_packet  >> core_session_read_frame >> frame >> core_session_write_frame >> rtp_common_write
socket_recvfrom --------------------------------------------------------------------> socket_sendto
[jb_put_packet/jb_get_packet]
rtp_session->recv_msg, bytes
```
How much time did the packet spent in the JB read_rtp_packet - switch_rtp_zerocopy_read_frame.


```
switch_rtp_zerocopy_read_frame : rtp packet to frame
```


read_rtp_packet (jb)
```
 switch_rtp.c:5857 READ_RTP_PACKET channel[0x7f30b8053450]b_s[0x7f30bc039df8]b_rt_s[0x7f30b80c4538]uuid_bridged[aceeafcc-1dc1-44dc-b100-0356ce1355bb] now[3060854]ssrc[538439328]ts[30025]seq[5280]b[172]timer[1]s[0]count[53]
 switch_rtp.c:5875 READ_RTP_PACKET: [ssrc:0x2017EEA0][x33][172.31.50.188:17906]-RTP->[36156]fs[32968]>RTP>[172.31.58.88:11404][ssrc:0x20F3EF62][x0]
```

switch_core_session_read_frame >> switch_core_session_write_frame
```
 switch_ivr_bridge.c:806 >>>> ivr_bridge - switch_core_session_read_frame ssrc[0x2017EEA0]seq[30025]ts[5280]codec[PCMU] 1t1 <<<<
 switch_ivr_bridge.c:828 >>>> ivr_bridge - switch_core_session_write_frame 1t1 <<<<
 switch_rtp.c:8823 >>>> sento ssrc[0x2017EEA0]seq[30025]ts[0]codec[opus] >> ssrc[0x20F3EF62]seq[61504]ts[?]codec[]
 switch_rtp.c:8373 RTP_COMMON_WRITE seq[61505] [1659892512] [3060854] timer[1] count[51]
 switch_ivr_bridge.c:834 >>>> ivr_bridge - switch_core_session_write_frame ssrc[0x2017EEA0]seq[30025]ts[5280]codec[PCMU] 1t1 <<<<
```
```